### PR TITLE
debian: add gbp configuration

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+upstream-tag = v%(version)s
+debian-branch=raspios/buster


### PR DESCRIPTION
Use upstream-tags with a v as prefix.
use raspios/buster a debian-branch

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>