### PR TITLE
Adapt debianization to bullseye environment [REVPI-3126]

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-revpi-modbus (1.1.0-1+revpi10+3) buster; urgency=medium
+revpi-modbus (1.1.0-1+revpi11+1) bullseye; urgency=medium
 
   * Remove invalid -b (branch name) part of Vcs-Git value
   * Set upstream-branch value in gbp.conf to master

--- a/debian/control
+++ b/debian/control
@@ -5,13 +5,13 @@ Maintainer: KUNBUS GmbH <support@kunbus.com>
 Rules-Requires-Root: no
 Homepage: https://revolutionpi.com/
 Vcs-Browser: https://github.com/RevolutionPi/revpi-modbus
-Vcs-Git: https://github.com/RevolutionPi/revpi-modbus.git
+Vcs-Git: https://github.com/RevolutionPi/revpi-modbus.git -b raspios/bullseye
 Build-Depends:
-  debhelper-compat (= 12),
+  debhelper-compat (= 13),
   libmodbus-dev (>= 3.1.6),
   libjson-c-dev,
   cmake
-Standards-Version: 4.3.0
+Standards-Version: 4.5.1
 
 Package: pimodbus-master
 Architecture: any

--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,7 +1,7 @@
 [DEFAULT]
 upstream-branch = master
 upstream-tag = v%(version)s
-debian-branch = raspios/buster
+debian-branch = raspios/bullseye
 debian-tag = raspios/%(version)s
 debian-tag-msg = %(pkg)s RaspiOS release %(version)s
 pristine-tar = True


### PR DESCRIPTION
 * Changed referenced branch and debhelper version to what is installed in Bullseye.
 * Since upstream version has increased, the Debian revision is reset.
 * Building packages for arm64 and armhf has been tested successfully
