### PR TITLE
fix: Daemons does not start after upgrade

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+revpi-modbus (1.1.0-1+revpi10+4) buster; urgency=medium
+
+  * fix: Daemons does not start after upgrade
+
+ -- Sven Sager <s.sager@kunbus.com>  Thu, 04 May 2023 08:16:39 +0200
+
 revpi-modbus (1.1.0-1+revpi10+3) buster; urgency=medium
 
   * Remove invalid -b (branch name) part of Vcs-Git value

--- a/debian/rules
+++ b/debian/rules
@@ -8,4 +8,4 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 	dh $@
 
 override_dh_installsystemd:
-	dh_installsystemd --no-enable --no-start
+	dh_installsystemd --no-enable


### PR DESCRIPTION
In Commit d054221, we changed from dh_systemd_enable to
dh_installsystemd. The parameter —no-start was added. This prevents a
start on the first installation of the package, but also on an upgrade.
This is the reason why the services stopped running after an upgrade of
the package.