### PR TITLE
fix: Daemons do not start after upgrade

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+revpi-modbus (1.1.0-1+revpi11+3) bullseye; urgency=medium
+
+  * fix: Daemons do not start after upgrade
+
+ -- Sven Sager <s.sager@kunbus.com>  Fri, 05 May 2023 13:09:48 +0200
+
 revpi-modbus (1.1.0-1+revpi11+2) bullseye; urgency=medium
 
   * Rename Debian packages for modbus

--- a/debian/rules
+++ b/debian/rules
@@ -8,4 +8,4 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 	dh $@
 
 override_dh_installsystemd:
-	dh_installsystemd --no-enable --no-start
+	dh_installsystemd --no-enable


### PR DESCRIPTION
In Commit d054221, we changed from dh_systemd_enable to
dh_installsystemd. The parameter —-no-start was added. This should
prevent a start on the first installation of the package, but it also
prevent a restart after package upgrade. Our unit file is installed
with -—no-enabled. This sets the unit file to disabled during
installation and dh-systemd-invoke will NOT start the program at the
first installation or upgrade until the user sets it to enabled. We can
and must remove —-no-start.