### PR TITLE
build: Use pkg-config for services install path

### DIFF
--- a/systemd/CMakeLists.txt
+++ b/systemd/CMakeLists.txt
@@ -1,2 +1,6 @@
+include(FindPkgConfig)
+pkg_check_modules(SYSTEMD REQUIRED "systemd")
+pkg_get_variable(SYSTEMD_SYSTEMUNITDIR "systemd" "systemdsystemunitdir")
+
 install(FILES pimodbus-master.service pimodbus-slave.service
-	DESTINATION /lib/systemd/system)
+	DESTINATION ${SYSTEMD_SYSTEMUNITDIR})


### PR DESCRIPTION
Install tree:

```
pkg
├── lib
│   └── systemd
│       └── system
│           ├── pimodbus-master.service
│           └── pimodbus-slave.service
└── usr
    └── local
        └── sbin
            ├── piModbusMaster
            └── piModbusSlave

7 directories, 4 files
```